### PR TITLE
fix(packages): tolerate EPERM/EISDIR on directory fsync (Windows)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased (local patch)
+
+- `package build` no longer fails on Windows with `EPERM: operation not
+  permitted, fsync`. `fsyncDirectory` (`src/packages/format.ts`) issued an
+  `fsync` on a directory handle for write durability, which Windows rejects with
+  `EPERM` (and `EISDIR` on some open paths); the catch only tolerated `EINVAL`
+  and `ENOTSUP`, so it rethrew and aborted the build. It now also skips `EPERM`
+  and `EISDIR`, matching the best-effort directory-fsync handling already in
+  `src/storage/jobs.ts`. The per-file `handle.sync()` calls still run, so file
+  durability is unchanged; only the (unsupported on Windows) directory flush is
+  skipped.
+
 ## 1.0.2
 
 Public plugin and CLI corrective release:

--- a/src/packages/format.ts
+++ b/src/packages/format.ts
@@ -178,7 +178,9 @@ async function fsyncDirectory(directory: string): Promise<void> {
       await handle.close();
     }
   } catch (error) {
-    if (!['EINVAL', 'ENOTSUP'].includes((error as NodeJS.ErrnoException).code ?? '')) throw error;
+    // Directory fsync is unsupported on some platforms/filesystems; Windows reports EPERM
+    // (or EISDIR on open). Per-file syncs already make the bytes durable; rename is atomic.
+    if (!['EINVAL', 'ENOTSUP', 'EPERM', 'EISDIR'].includes((error as NodeJS.ErrnoException).code ?? '')) throw error;
   }
 }
 


### PR DESCRIPTION
## Problem

`game-dev package build` fails on Windows with:

```
{ "error": "UNKNOWN", "message": "EPERM: operation not permitted, fsync", "retryable": false }
```

`fsyncDirectory` in `src/packages/format.ts` opens a **directory** handle and calls `handle.sync()` for write-durability of the staged package and its parent. Windows does not permit `fsync` on a directory handle — Node rejects it with `EPERM` (and `EISDIR` on some open paths). The `catch` only tolerated `EINVAL` / `ENOTSUP`, so it rethrew and aborted the build at `writePackage` (lines ~255/257).

Reproduced with the bundled Node runtime:

```js
const h = await fs.open('C:/some/dir', 'r');
await h.sync();   // -> EPERM: operation not permitted, fsync
```

## Fix

Add `EPERM` and `EISDIR` to the tolerated set in `fsyncDirectory`. This matches the best-effort directory-fsync handling already present in `src/storage/jobs.ts` (which treats directory fsync as unsupported-on-some-platforms and swallows the failure).

The per-file `handle.sync()` calls in `writeFileAtomic` / `writePackage` still run, so the durability guarantee for the package's file *contents* is unchanged; only the directory-entry flush — which Windows cannot provide — is skipped, and `fs.rename` is atomic regardless.

## Verified

After the change, `game-dev package build` and `game-dev vendor admit --confirm` both complete on Windows 11 (Node bundled with the CLI). `package verify` passes on the produced package.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)